### PR TITLE
Fixed the way that test sets flags

### DIFF
--- a/src/opcodes/Test.cpp
+++ b/src/opcodes/Test.cpp
@@ -4,7 +4,7 @@
 |
 |  Creation Date: 06-10-2012
 |
-|  Last Modified: Tue, Oct  9, 2012  4:54:40 PM
+|  Last Modified: Wed, Oct 10, 2012  9:24:12 AM
 |
 |  Created By: Robert Nelson
 |
@@ -113,6 +113,8 @@ int Test::Execute(Processor* proc) {
 	parity ^= parity >> 4;
 	parity &= 0x0f;
 	
+	proc->SetFlag(FLAGS_CF, false);
+	proc->SetFlag(FLAGS_OF, false);
 	proc->SetFlag(FLAGS_PF, (0x6996 >> parity) & 1);
 	proc->SetFlag(FLAGS_ZF, val == 0);
 	proc->SetFlag(FLAGS_SF, val >= sign);

--- a/src/opcodes/Test.hpp
+++ b/src/opcodes/Test.hpp
@@ -4,7 +4,7 @@
 |
 |  Creation Date: 06-10-2012
 |
-|  Last Modified: Sat, Oct  6, 2012 10:33:39 PM
+|  Last Modified: Tue, Oct  9, 2012  8:53:12 PM
 |
 |  Created By: Robert Nelson
 |
@@ -31,7 +31,7 @@ class Test : public Instruction {
 
 		static const unsigned int TEST_SUB_OPCODE = 0x00;
 
-	private:
+	protected:
 		Test(Prefix* pre, std::string text, std::string inst, int op);
 
 };


### PR DESCRIPTION
Test was originally missing the clearing of CF and OF. This has been remedied.
