### PR TITLE
Disasm includes length.

### DIFF
--- a/src/Instruction.hpp
+++ b/src/Instruction.hpp
@@ -4,7 +4,7 @@
 |
 |  Creation Date: 25-09-2012
 |
-|  Last Modified: Thu, Oct 18, 2012  9:03:13 PM
+|  Last Modified: Thu, Oct 18, 2012 10:30:26 PM
 |
 |  Created By: Robert Nelson
 |
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <vector>
+#include <sstream>
 
 #include "Prefix.hpp"
 #include "Operand.hpp"
@@ -73,6 +74,12 @@ class Instruction {
 		static bool AdjustSub(unsigned int op1, unsigned int op2);
 
 		inline std::string GetDisasm() { return mText; }
+
+		void AddLengthToDisasm() {
+			std::stringstream ss;
+			ss << mInst.size();
+			mText += " (" + ss.str() + ")";
+		}
 
 	protected:
 		Instruction();

--- a/src/ModrmOperand.cpp
+++ b/src/ModrmOperand.cpp
@@ -4,7 +4,7 @@
 |
 |  Creation Date: 28-09-2012
 |
-|  Last Modified: Thu, Oct 18, 2012 10:06:04 PM
+|  Last Modified: Thu, Oct 18, 2012 10:45:36 PM
 |
 |  Created By: Robert Nelson
 |
@@ -139,7 +139,8 @@ Operand* ModrmOperand::GetModrmOperand(Processor* proc, unsigned char* inst, eMo
 			//Special case for direct mem access
 			if((*modrm & 0x07) == 6) {
 				disp = *(modrm + 1) + ((*(modrm + 2)) << 8);
-				ss << "[" << disp << "]";
+				ss << "[0x" << std::uppercase << std::hex
+					<< disp << std::nouppercase << std::dec << "]";
 				newMod = new ModrmOperand(proc, disp % 0x10000, size, 2);
 				newMod->mText = ss.str();
 				return newMod;

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -4,7 +4,7 @@
 |
 |  Creation Date: 26-09-2012
 |
-|  Last Modified: Thu, Oct 18, 2012  9:14:23 PM
+|  Last Modified: Thu, Oct 18, 2012 10:52:07 PM
 |
 |  Created By: Robert Nelson
 |
@@ -44,6 +44,7 @@ int Processor::Step() {
 	if(inst && inst->IsValid()) {
 		//Increment IP
 		SetRegister(REG_IP, GetRegister(REG_IP) + inst->GetLength());
+		inst->AddLengthToDisasm();
 
 		std::cout << inst->GetDisasm() << std::endl;
 


### PR DESCRIPTION
Also fixed immediate addresses rendering in decimal, now renders in hex.
