### PR TITLE
Added interrupts to keyboard.

### DIFF
--- a/src/MemWnd.cpp
+++ b/src/MemWnd.cpp
@@ -221,6 +221,7 @@ void MemWnd::UpdateGui() {
 	ui->chkParity->setChecked(mVM.GetProc().GetFlag(FLAGS_PF));
 	ui->chkZero->setChecked(mVM.GetProc().GetFlag(FLAGS_ZF));
 	ui->chkSign->setChecked(mVM.GetProc().GetFlag(FLAGS_SF));
+	ui->chkInterrupt->setChecked(mVM.GetProc().GetFlag(FLAGS_IF));
 	UpdateMemView();
 
 	unsigned int ip = mVM.GetProc().GetRegister(REG_IP);

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -67,7 +67,7 @@ void Processor::_InitializeDevices() {
 	mDevices.clear();
 
 	mDevices.push_back(new Screen());
-	mDevices.push_back(new Keyboard());
+	mDevices.push_back(new Keyboard(const_cast<Processor*>(this)));
 }
 
 //Execute a single instruction

--- a/src/VMWorker.cpp
+++ b/src/VMWorker.cpp
@@ -25,7 +25,7 @@ void VMWorker::run() {
 				emit breakpoint();
 				return;
 			} else if(err > 0) {
-				emit procReturn(err);
+			//	emit procReturn(err);
 			}
 			mVM->notifyReadCallbacks();
 			mVM->notifyWriteCallbacks();
@@ -33,6 +33,7 @@ void VMWorker::run() {
 			updateCtr = (updateCtr + 1) % 300;
 			if(updateCtr == 0)
 				emit stepDone();
+			usleep(50);
 		}
 		emit error(err);
 	} else {

--- a/src/peripherals/Keyboard.hpp
+++ b/src/peripherals/Keyboard.hpp
@@ -13,19 +13,21 @@
 #pragma once
 
 #include "../IPeripheral.hpp"
+#include "../Processor.hpp"
 
-#define KBD_CTRL_DATA_AVAIL	0x02
-#define KBD_CTRL_POLL		0x10
+#define KBD_CTRL_INTERRUPT	0x01
+#define KBD_CTRL_ENABLE		0x10
 
-#define KBD_STAT_DATA_AVAIL	0x02
-#define KBD_STAT_POLL		0x10
+#define KBD_STAT_DATA_AVAIL	0x01
 
 #define KBD_DATA_PORT		0x60
 #define KBD_STAT_PORT		0x64
 
+#define KBD_IRQ			0x09
+
 class Keyboard : public IPeripheral {
 	public:
-		Keyboard();
+		Keyboard(Processor* proc);
 
 		bool Put8(unsigned int port, unsigned int data);
 		bool Put16(unsigned int port, unsigned int data);
@@ -44,4 +46,6 @@ class Keyboard : public IPeripheral {
 		unsigned char dataBuffer;
 		unsigned char statBuffer;
 		unsigned char ctrlBuffer;
+
+		Processor* mProc;
 };


### PR DESCRIPTION
They're disabled by default, but can be enabled by writing 0x11 to port 0x60.
On keypress, interupt 9 (address 0x0024) is triggered.

Finishes addition of feature #70.
