### PR TITLE
Fixed a segfault caused by mLastDevice not being cleared.

### DIFF
--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -65,6 +65,8 @@ void Processor::_InitializeDevices() {
 		delete mDevices[i];
 	}
 	mDevices.clear();
+	mLastPort = 0xFFFFFFFF;
+	mLastDevice = 0;
 
 	mDevices.push_back(new Screen());
 	mDevices.push_back(new Keyboard(const_cast<Processor*>(this)));


### PR DESCRIPTION
Error occurred on processor reinitialization when a the most recently accessed port was accessed on the new execution.
