### PR TITLE
Fixed issue #91.

### DIFF
--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -48,6 +48,7 @@ int Processor::Initialize(unsigned int startAddr) {
 	SetRegister(REG_DI, 0x0000);
 	SetRegister(REG_FLAGS, 0x0000);
 	SetRegister(REG_IP, startAddr);
+	mHalt = false;
 
 	_InitializeDevices();
 


### PR DESCRIPTION
Reinitialize the mHalt variable when reinitializing the processor object.
