### PR TITLE
Fixed #92. Timer now checks for div by zero.

### DIFF
--- a/src/peripherals/Timer.cpp
+++ b/src/peripherals/Timer.cpp
@@ -86,7 +86,7 @@ void Timer::Dump() {
 
 void Timer::Update() {
 	mProc->SetInterrupt(TIMER_IRQ);
-	if(mTimer) {
+	if(mTimer && dataBuffer != 0) {
 		mTimer->setInterval(TIMER_FREQ/dataBuffer);
 		mTimer->start();
 	}


### PR DESCRIPTION
Added a simple check for a zero value before performing division.
