### PR TITLE
Improvement for #93. Screen updates now forced on calls to OUT

### DIFF
--- a/src/MemWnd.cpp
+++ b/src/MemWnd.cpp
@@ -83,6 +83,7 @@ MemWnd::MemWnd(const char* const file, QWidget *parent) :
 	connect(mVMWorker, SIGNAL(stepDone()), this, SLOT(workerStepDone()));
 	connect(mVMWorker, SIGNAL(error(int)), this, SLOT(workerRunError(int)));
 	connect(mVMWorker, SIGNAL(quit()), mVMWorker, SLOT(deleteLater()));
+	connect(mVMWorker, SIGNAL(procReturn(int)), this, SLOT(workerProcReturn(int)));
 	connect(this, SIGNAL(vmResume()), mVMWorker, SLOT(run()));
 	connect(this, SIGNAL(vmStep()), mVMWorker, SLOT(step()));
 	connect(this, SIGNAL(vmPause()), mVMWorker, SLOT(pause()));
@@ -351,6 +352,12 @@ void MemWnd::workerStepDone() {
 	UpdateScreen();
 	mVM.notifyReadCallbacks();
 	mVM.notifyWriteCallbacks();
+}
+//Program's processor returned an info code
+void MemWnd::workerProcReturn(int err) {
+	if(err == Processor::PROC_PERIPH_WRITE) {
+		UpdateScreen();
+	}
 }
 
 /*

--- a/src/MemWnd.hpp
+++ b/src/MemWnd.hpp
@@ -46,6 +46,8 @@ public slots:
 	void workerRunError(int err);
 	//trigger on run paused
 	void workerPaused();
+	//trigger on proc return positive
+	void workerProcReturn(int err);
 
 	void KeyEvent(QKeyEvent*);
 	void TimerEvent();

--- a/src/Processor.hpp
+++ b/src/Processor.hpp
@@ -74,6 +74,7 @@ class Processor {
 
 		static const int PROC_SUCCESS		=  0;
 		static const int PROC_HALT		=  1;
+		static const int PROC_PERIPH_WRITE	=  2;
 		static const int PROC_ERR_INV_ADDR 	= -1;
 		static const int PROC_ERR_INV_INST 	= -2;
 		static const int PROC_ERR_INST		= -3;

--- a/src/VMWorker.cpp
+++ b/src/VMWorker.cpp
@@ -8,7 +8,6 @@ VMWorker::VMWorker(VM* vm) : mVM(vm), mPaused(false)
 
 void VMWorker::run() {
 	int err;
-	int updateCtr = 0;
 	mPaused = false;
 	if(mVM && mVM->isLoaded()) {
 		for(EVER) {
@@ -24,17 +23,10 @@ void VMWorker::run() {
 				emit procReturn(err);
 				emit breakpoint();
 				return;
-			} else if(err > 0) {
-			//	emit procReturn(err);
+			} else if(err == Processor::PROC_PERIPH_WRITE) {
+				emit procReturn(err);
 			}
-			mVM->notifyReadCallbacks();
-			mVM->notifyWriteCallbacks();
-			//Only update the GUI every 300 instructions (~0.005 seconds)
-			updateCtr = (updateCtr + 1) % 300;
-			if(updateCtr == 0)
-				emit stepDone();
-			//This prevents CPU Burning, currently a randomly small value
-			usleep(50);
+			usleep(15);
 		}
 		emit error(err);
 	} else {

--- a/src/opcodes/Out.cpp
+++ b/src/opcodes/Out.cpp
@@ -76,10 +76,10 @@ int Out::Execute(Processor* proc) {
 
 	if(mOpcode == OUT_IMM8_AL || mOpcode == OUT_DX_AL) {
 		proc->Outb(dst->GetValue(), src->GetValue());
-		return 0;
+		return Processor::PROC_PERIPH_WRITE;
 	} else if(mOpcode == OUT_IMM8_AX || mOpcode == OUT_DX_AX) {
 		proc->Outw(dst->GetValue(), src->GetValue());
-		return 0;
+		return Processor::PROC_PERIPH_WRITE;
 	}
 
 	return INVALID_ARGS;


### PR DESCRIPTION
The screen cannot be updated except on calls to OUT. This change only triggers a GUI update when OUT is called.
