### PR TITLE
Fixed #105. Step out works properly again.

### DIFF
--- a/src/Instruction.hpp
+++ b/src/Instruction.hpp
@@ -87,11 +87,12 @@ class Instruction {
 		}
 
 		enum eExecuteRetCode {
-			SUCCESS		=  0,
-			INVALID_ARGS 	= -1,
-			RET_CALLED	=  1,
-			CALL_CALLED	=  2,
-			RES_BREAKPOINT = 3
+			INVALID_ARGS = -1,
+			SUCCESS,
+			RET_CALLED,
+			CALL_CALLED,
+			RES_BREAKPOINT,
+			PERIPH_WRITE,
 		};
 
 

--- a/src/MemWnd.cpp
+++ b/src/MemWnd.cpp
@@ -355,7 +355,7 @@ void MemWnd::workerStepDone() {
 }
 //Program's processor returned an info code
 void MemWnd::workerProcReturn(int err) {
-	if(err == Processor::PROC_PERIPH_WRITE) {
+	if(err == Instruction::PERIPH_WRITE) {
 		UpdateScreen();
 	}
 }

--- a/src/Processor.hpp
+++ b/src/Processor.hpp
@@ -74,7 +74,6 @@ class Processor {
 
 		static const int PROC_SUCCESS		=  0;
 		static const int PROC_HALT		=  1;
-		static const int PROC_PERIPH_WRITE	=  2;
 		static const int PROC_ERR_INV_ADDR 	= -1;
 		static const int PROC_ERR_INV_INST 	= -2;
 		static const int PROC_ERR_INST		= -3;

--- a/src/VMWorker.cpp
+++ b/src/VMWorker.cpp
@@ -23,7 +23,7 @@ void VMWorker::run() {
 				emit procReturn(err);
 				emit breakpoint();
 				return;
-			} else if(err == Processor::PROC_PERIPH_WRITE) {
+			} else if(err == Instruction::PERIPH_WRITE) {
 				emit procReturn(err);
 			}
 			usleep(15);

--- a/src/opcodes/Out.cpp
+++ b/src/opcodes/Out.cpp
@@ -76,10 +76,10 @@ int Out::Execute(Processor* proc) {
 
 	if(mOpcode == OUT_IMM8_AL || mOpcode == OUT_DX_AL) {
 		proc->Outb(dst->GetValue(), src->GetValue());
-		return Processor::PROC_PERIPH_WRITE;
+		return Instruction::PERIPH_WRITE;
 	} else if(mOpcode == OUT_IMM8_AX || mOpcode == OUT_DX_AX) {
 		proc->Outw(dst->GetValue(), src->GetValue());
-		return Processor::PROC_PERIPH_WRITE;
+		return Instruction::PERIPH_WRITE;
 	}
 
 	return INVALID_ARGS;


### PR DESCRIPTION
Problem stemmed from a conflict between CALL_CALLED and PROC_PERIPH_WRITE
causing all calls to 'out dx, al' to be seen as a new call for the purposes
of step over.
