### PR TITLE
Jcc fix 2

### DIFF
--- a/src/opcodes/Jcc.cpp
+++ b/src/opcodes/Jcc.cpp
@@ -174,8 +174,9 @@ int Jcc::Execute(Processor* proc) {
 		unsigned int newIP = proc->GetRegister(REG_IP);
 		unsigned int relAddr = src->GetValue();
 		if (relAddr & 0x80)
-			relAddr |= std::numeric_limits<int>::max() << 8; // If relAddr is 8 bit negative, negate
-		newIP += relAddr;
+			newIP -= 0xFF & (~relAddr + 1);
+		else 
+			newIP += relAddr;
 		newIP &= 0xFFFF;
 		proc->SetRegister(REG_IP, newIP);
 	}

--- a/src/opcodes/Jcc.cpp
+++ b/src/opcodes/Jcc.cpp
@@ -17,7 +17,6 @@
 #include "../Prefix.hpp"
 
 #include <cstdio>
-#include <limits>
 
 const char Jcc::JA_STR[] = "JA";
 const char Jcc::JB_STR[] = "JB";


### PR DESCRIPTION
Fixed the compile error on Linux without an extra include. Also easier to read code.
