### PR TITLE
GUI Controls now update the processor state.

### DIFF
--- a/src/MemWnd.cpp
+++ b/src/MemWnd.cpp
@@ -473,6 +473,8 @@ void MemWnd::UpdateFlags() {
 	ui->chkZero->setChecked(mVM.GetProc().GetFlag(FLAGS_ZF));
 	ui->chkSign->setChecked(mVM.GetProc().GetFlag(FLAGS_SF));
 	ui->chkInterrupt->setChecked(mVM.GetProc().GetFlag(FLAGS_IF));
+	ui->chkDirection->setChecked(mVM.GetProc().GetFlag(FLAGS_DF));
+	ui->chkTrap->setChecked(mVM.GetProc().GetFlag(FLAGS_TF));
 }
 
 void MemWnd::UpdateGui() {

--- a/src/MemWnd.cpp
+++ b/src/MemWnd.cpp
@@ -16,6 +16,7 @@
 #include "peripherals/Keyboard.hpp"
 #include "peripherals/Timer.hpp"
 #include "QKbdFilter.hpp"
+#include "Processor.hpp"
 
 #include <QTimer>
 #include <iostream>
@@ -107,6 +108,17 @@ MemWnd::MemWnd(const char* const file, QWidget *parent) :
 	connect(mVMWorker, SIGNAL(stopped()), this, SLOT(workerStopped()));
 	connect(this, SIGNAL(vmResume()), mVMWorker, SLOT(run()));
 	connect(this, SIGNAL(vmPause()), mVMWorker, SLOT(pause()));
+
+	//Connect the flag controls
+	connect(this->ui->chkAdjust, SIGNAL(stateChanged(int)), this, SLOT(adjustFlagChanged(int)));
+	connect(this->ui->chkCarry, SIGNAL(stateChanged(int)), this, SLOT(carryFlagChanged(int)));
+	connect(this->ui->chkDirection, SIGNAL(stateChanged(int)), this, SLOT(directionFlagChanged(int)));
+	connect(this->ui->chkInterrupt, SIGNAL(stateChanged(int)), this, SLOT(interruptFlagChanged(int)));
+	connect(this->ui->chkOverflow, SIGNAL(stateChanged(int)), this, SLOT(overflowFlagChanged(int)));
+	connect(this->ui->chkParity, SIGNAL(stateChanged(int)), this, SLOT(parityFlagChanged(int)));
+	connect(this->ui->chkSign, SIGNAL(stateChanged(int)), this, SLOT(signFlagChanged(int)));
+	connect(this->ui->chkTrap, SIGNAL(stateChanged(int)), this, SLOT(trapFlagChanged(int)));
+	connect(this->ui->chkZero, SIGNAL(stateChanged(int)), this, SLOT(zeroFlagChanged(int)));
 
 	//Initialize the timer's QTimer object
 	QTimer* baseTimer = new QTimer();
@@ -732,3 +744,17 @@ void MemWnd::TimerEvent() {
 void MemWnd::UpdateScreenTick() {
 	UpdateScreen();
 }
+
+///Checkbox Flag update Functions
+
+void MemWnd::adjustFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_AF, state == Qt::Checked); }
+void MemWnd::carryFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_CF, state == Qt::Checked); }
+void MemWnd::directionFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_DF, state == Qt::Checked); }
+void MemWnd::interruptFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_IF, state == Qt::Checked); }
+void MemWnd::overflowFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_OF, state == Qt::Checked); }
+void MemWnd::parityFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_PF, state == Qt::Checked); }
+void MemWnd::signFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_SF, state == Qt::Checked); }
+void MemWnd::trapFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_TF, state == Qt::Checked); }
+void MemWnd::zeroFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_ZF, state == Qt::Checked); }
+
+///End Checkbox Flag update Functions

--- a/src/MemWnd.cpp
+++ b/src/MemWnd.cpp
@@ -120,6 +120,18 @@ MemWnd::MemWnd(const char* const file, QWidget *parent) :
 	connect(this->ui->chkTrap, SIGNAL(stateChanged(int)), this, SLOT(trapFlagChanged(int)));
 	connect(this->ui->chkZero, SIGNAL(stateChanged(int)), this, SLOT(zeroFlagChanged(int)));
 
+	//Connect the register controls
+	connect(this->ui->txtAX, SIGNAL(editingFinished()), this, SLOT(axChanged()));
+	connect(this->ui->txtBX, SIGNAL(editingFinished()), this, SLOT(bxChanged()));
+	connect(this->ui->txtCX, SIGNAL(editingFinished()), this, SLOT(cxChanged()));
+	connect(this->ui->txtDX, SIGNAL(editingFinished()), this, SLOT(dxChanged()));
+	connect(this->ui->txtSP, SIGNAL(editingFinished()), this, SLOT(spChanged()));
+	connect(this->ui->txtBP, SIGNAL(editingFinished()), this, SLOT(bpChanged()));
+	connect(this->ui->txtSI, SIGNAL(editingFinished()), this, SLOT(siChanged()));
+	connect(this->ui->txtDI, SIGNAL(editingFinished()), this, SLOT(diChanged()));
+	connect(this->ui->txtFLAGS, SIGNAL(editingFinished()), this, SLOT(flChanged()));
+	connect(this->ui->txtIP, SIGNAL(editingFinished()), this, SLOT(ipChanged()));
+
 	//Initialize the timer's QTimer object
 	QTimer* baseTimer = new QTimer();
 	connect(baseTimer, SIGNAL(timeout()), this, SLOT(TimerEvent()));
@@ -758,3 +770,44 @@ void MemWnd::trapFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_TF, state 
 void MemWnd::zeroFlagChanged(int state) { mVM.GetProc().SetFlag(FLAGS_ZF, state == Qt::Checked); }
 
 ///End Checkbox Flag update Functions
+
+
+///Register update functions
+
+bool MemWnd::_validRegText(const QString& text) {
+	if (text.length() > 4)  // 5 characters exceeds bounds
+		return false;
+
+	for (int i = 0; i < text.length(); i++) {
+		if (!text.at(i).isDigit() && !(text.at(i).toLower().toAscii() >= 'a' && text.at(i).toLower().toAscii() <= 'f'))
+			return false;
+	}
+	return true;
+}
+
+unsigned int MemWnd::_htoi(const QString& text) {
+	unsigned int retVal = 0;
+
+	for (int i = 0; i < text.length(); i++) {
+		char lower = text.at(i).toLower().toAscii();
+		if(text.at(i).isDigit()) {
+			retVal += (text.at(i).toAscii() - '0') << ((text.length() - i - 1) * 4);
+		} else if (lower >= 'a' && lower <= 'f') {
+			retVal += (lower - 'a' + 10) << ((text.length() - i - 1) * 4);
+		}
+	}
+	return retVal;
+}
+
+void MemWnd::axChanged() { if (_validRegText(this->ui->txtAX->text())) { mVM.GetProc().SetRegister(REG_AX, _htoi(this->ui->txtAX->text())); } ui->txtAX->setText(mVM.GetProc().GetRegisterHex(REG_AX)); }
+void MemWnd::bxChanged() { if (_validRegText(this->ui->txtBX->text())) { mVM.GetProc().SetRegister(REG_BX, _htoi(this->ui->txtBX->text())); } ui->txtBX->setText(mVM.GetProc().GetRegisterHex(REG_BX)); }
+void MemWnd::cxChanged() { if (_validRegText(this->ui->txtCX->text())) { mVM.GetProc().SetRegister(REG_CX, _htoi(this->ui->txtCX->text())); } ui->txtCX->setText(mVM.GetProc().GetRegisterHex(REG_CX)); }
+void MemWnd::dxChanged() { if (_validRegText(this->ui->txtDX->text())) { mVM.GetProc().SetRegister(REG_DX, _htoi(this->ui->txtDX->text())); } ui->txtDX->setText(mVM.GetProc().GetRegisterHex(REG_DX)); }
+void MemWnd::spChanged() { if (_validRegText(this->ui->txtSP->text())) { mVM.GetProc().SetRegister(REG_SP, _htoi(this->ui->txtSP->text())); } ui->txtSP->setText(mVM.GetProc().GetRegisterHex(REG_SP)); }
+void MemWnd::bpChanged() { if (_validRegText(this->ui->txtBP->text())) { mVM.GetProc().SetRegister(REG_BP, _htoi(this->ui->txtBP->text())); } ui->txtBP->setText(mVM.GetProc().GetRegisterHex(REG_BP)); }
+void MemWnd::siChanged() { if (_validRegText(this->ui->txtSI->text())) { mVM.GetProc().SetRegister(REG_SI, _htoi(this->ui->txtSI->text())); } ui->txtSI->setText(mVM.GetProc().GetRegisterHex(REG_SI)); }
+void MemWnd::diChanged() { if (_validRegText(this->ui->txtDI->text())) { mVM.GetProc().SetRegister(REG_DI, _htoi(this->ui->txtDI->text())); } ui->txtDI->setText(mVM.GetProc().GetRegisterHex(REG_DI)); }
+void MemWnd::flChanged() { if (_validRegText(this->ui->txtFLAGS->text())) { mVM.GetProc().SetRegister(REG_FLAGS, _htoi(this->ui->txtFLAGS->text())); } ui->txtFLAGS->setText(mVM.GetProc().GetRegisterHex(REG_FLAGS)); }
+void MemWnd::ipChanged() { if (_validRegText(this->ui->txtIP->text())) { mVM.GetProc().SetRegister(REG_IP, _htoi(this->ui->txtIP->text())); } else { ui->txtIP->setText(mVM.GetProc().GetRegisterHex(REG_IP)); } }
+
+///End register update functions

--- a/src/MemWnd.hpp
+++ b/src/MemWnd.hpp
@@ -87,6 +87,12 @@ public slots:
 
 	/// End Register update functions
 
+	/// Begin Memory update function
+
+	void memChanged(const QModelIndex&, const QModelIndex&);
+
+	/// End memory update function
+
 signals:
 	void vmResume();
 	void vmStep();
@@ -106,9 +112,8 @@ private:
 	void ClearRegisterHighlighting();
 	void HighlightBreakpoints();
 	void DisableRun(int err);
+	void SetMemoryEditState(bool editable);
 	void EnableRun();
-	bool _validRegText(const QString&);
-	unsigned int _htoi(const QString&);
 
 	VM mVM;
 	QString mFile;

--- a/src/MemWnd.hpp
+++ b/src/MemWnd.hpp
@@ -99,6 +99,7 @@ private:
 	void loadFile(bool newFile = false);
 	void UpdateScreen();
 	void UpdateGui();
+	void UpdateFlags();
 	void UpdateMemView(unsigned int ip = 0xFFFFFFFF, unsigned int len = 0);
 	void UpdateInstHighlight();
 	void UpdateInstructions();
@@ -117,6 +118,7 @@ private:
 	int COL_LABEL;
 	int COL_LST;
 	int COL_INST;
+	bool ipWarned;
 
 };
 

--- a/src/MemWnd.hpp
+++ b/src/MemWnd.hpp
@@ -72,6 +72,21 @@ public slots:
 
 	/// End Flag Updates
 
+	/// Register update functions
+
+	void axChanged();
+	void bxChanged();
+	void cxChanged();
+	void dxChanged();
+	void spChanged();
+	void bpChanged();
+	void siChanged();
+	void diChanged();
+	void flChanged();
+	void ipChanged();
+
+	/// End Register update functions
+
 signals:
 	void vmResume();
 	void vmStep();
@@ -91,6 +106,8 @@ private:
 	void HighlightBreakpoints();
 	void DisableRun(int err);
 	void EnableRun();
+	bool _validRegText(const QString&);
+	unsigned int _htoi(const QString&);
 
 	VM mVM;
 	QString mFile;

--- a/src/MemWnd.hpp
+++ b/src/MemWnd.hpp
@@ -58,6 +58,20 @@ public slots:
 	void TimerEvent();
 	void UpdateScreenTick();
 
+	/// Flag Update Functions
+
+	void adjustFlagChanged(int);
+	void carryFlagChanged(int);
+	void directionFlagChanged(int);
+	void interruptFlagChanged(int);
+	void overflowFlagChanged(int);
+	void parityFlagChanged(int);
+	void signFlagChanged(int);
+	void trapFlagChanged(int);
+	void zeroFlagChanged(int);
+
+	/// End Flag Updates
+
 signals:
 	void vmResume();
 	void vmStep();

--- a/src/MemWnd.ui
+++ b/src/MemWnd.ui
@@ -215,13 +215,13 @@
                 </font>
                </property>
                <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
+                <enum>Qt::ClickFocus</enum>
                </property>
                <property name="text">
                 <string>0000</string>
                </property>
                <property name="readOnly">
-                <bool>true</bool>
+                <bool>false</bool>
                </property>
               </widget>
               <widget class="QLabel" name="label_3">
@@ -252,13 +252,13 @@
                 </font>
                </property>
                <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
+                <enum>Qt::ClickFocus</enum>
                </property>
                <property name="text">
                 <string>0000</string>
                </property>
                <property name="readOnly">
-                <bool>true</bool>
+                <bool>false</bool>
                </property>
               </widget>
               <widget class="QLabel" name="label_4">
@@ -289,13 +289,13 @@
                 </font>
                </property>
                <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
+                <enum>Qt::ClickFocus</enum>
                </property>
                <property name="text">
                 <string>0000</string>
                </property>
                <property name="readOnly">
-                <bool>true</bool>
+                <bool>false</bool>
                </property>
               </widget>
               <widget class="QLabel" name="label_5">
@@ -326,13 +326,13 @@
                 </font>
                </property>
                <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
+                <enum>Qt::ClickFocus</enum>
                </property>
                <property name="text">
                 <string>0000</string>
                </property>
                <property name="readOnly">
-                <bool>true</bool>
+                <bool>false</bool>
                </property>
               </widget>
               <widget class="QLabel" name="label_6">
@@ -363,13 +363,13 @@
                 </font>
                </property>
                <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
+                <enum>Qt::ClickFocus</enum>
                </property>
                <property name="text">
                 <string>0000</string>
                </property>
                <property name="readOnly">
-                <bool>true</bool>
+                <bool>false</bool>
                </property>
               </widget>
               <widget class="QLabel" name="label_7">
@@ -400,13 +400,13 @@
                 </font>
                </property>
                <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
+                <enum>Qt::ClickFocus</enum>
                </property>
                <property name="text">
                 <string>0000</string>
                </property>
                <property name="readOnly">
-                <bool>true</bool>
+                <bool>false</bool>
                </property>
               </widget>
               <widget class="QLabel" name="label_8">
@@ -437,13 +437,13 @@
                 </font>
                </property>
                <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
+                <enum>Qt::ClickFocus</enum>
                </property>
                <property name="text">
                 <string>0000</string>
                </property>
                <property name="readOnly">
-                <bool>true</bool>
+                <bool>false</bool>
                </property>
               </widget>
               <widget class="QLabel" name="label_9">
@@ -474,13 +474,13 @@
                 </font>
                </property>
                <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
+                <enum>Qt::ClickFocus</enum>
                </property>
                <property name="text">
                 <string>0000</string>
                </property>
                <property name="readOnly">
-                <bool>true</bool>
+                <bool>false</bool>
                </property>
               </widget>
               <widget class="QLineEdit" name="txtFLAGS">
@@ -498,13 +498,13 @@
                 </font>
                </property>
                <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
+                <enum>Qt::ClickFocus</enum>
                </property>
                <property name="text">
                 <string>0000</string>
                </property>
                <property name="readOnly">
-                <bool>true</bool>
+                <bool>false</bool>
                </property>
               </widget>
               <widget class="QLabel" name="label_10">
@@ -535,13 +535,13 @@
                 </font>
                </property>
                <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
+                <enum>Qt::ClickFocus</enum>
                </property>
                <property name="text">
                 <string>0000</string>
                </property>
                <property name="readOnly">
-                <bool>true</bool>
+                <bool>false</bool>
                </property>
               </widget>
               <widget class="QLabel" name="label_11">
@@ -768,7 +768,7 @@
      <x>0</x>
      <y>0</y>
      <width>1004</width>
-     <height>20</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">

--- a/src/MemWnd.ui
+++ b/src/MemWnd.ui
@@ -718,6 +718,12 @@
             <family>Courier New</family>
            </font>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::WheelFocus</enum>
+          </property>
+          <property name="editTriggers">
+           <set>QAbstractItemView::DoubleClicked</set>
+          </property>
           <attribute name="horizontalHeaderHighlightSections">
            <bool>true</bool>
           </attribute>

--- a/src/Processor.cpp
+++ b/src/Processor.cpp
@@ -96,6 +96,7 @@ int Processor::Step() {
 		PushRegister(REG_IP);
 		SetRegister(REG_IP, GetMemory(mInterrupt << 2, 2));
 		Memory::MemoryOffset curMem = mMem.getOffset(GetRegister(REG_IP));
+		delete mNextInst;
 		mNextInst = Instruction::ReadInstruction(curMem, this);
 		mInterrupt = -1;
 		mHalt = false;
@@ -411,6 +412,21 @@ void Processor::DeviceDump() {
 	for(unsigned int i = 0; i < mDevices.size(); i++) {
 		mDevices[i]->Dump();
 	}
+}
+
+bool Processor::ForceReloadInstruction(unsigned int IP) {
+
+	Memory::MemoryOffset curMem = mMem.getOffset(IP);
+	Instruction* tmpInst = Instruction::ReadInstruction(curMem, this);
+
+	if(tmpInst && tmpInst->IsValid()) {
+		delete mNextInst;
+		SetRegister(REG_IP, IP);
+		mNextInst = tmpInst;
+		return true;
+	}
+
+	return false;
 }
 
 void Processor::SetInterrupt(unsigned char n) {

--- a/src/Processor.hpp
+++ b/src/Processor.hpp
@@ -122,7 +122,7 @@ class Processor {
 		void MemDump();
 		void DeviceDump();
 
-
+		bool ForceReloadInstruction(unsigned int);
 
 	private:
 

--- a/src/QMemModel.cpp
+++ b/src/QMemModel.cpp
@@ -82,7 +82,11 @@ void QMemModel::Highlight(const int addr, const int len, const QColor color) {
 }
 
 Qt::ItemFlags QMemModel::flags(const QModelIndex&) const {
-	return Qt::ItemIsEnabled | Qt::ItemIsSelectable | ( mEditable ? Qt::ItemIsEditable : 0);
+	Qt::ItemFlags retVal = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+	if(mEditable)
+		retVal |= Qt::ItemIsEditable;
+
+	return retVal;
 }
 
 unsigned int QMemModel::_htoi(const QString& text) {

--- a/src/QMemModel.hpp
+++ b/src/QMemModel.hpp
@@ -20,6 +20,12 @@ public:
 	QVariant headerData(int section, Qt::Orientation orientation, int role) const;
 	void Highlight(const int addr, const int len, const QColor color);
 	void ClearHighlights() { mHighlight.clear(); }
+	Qt::ItemFlags flags(const QModelIndex& index) const;
+	void setEditable(bool editable) { mEditable = editable; }
+	bool isDirty() { return mDirty; }
+	bool clean() { mDirty = false; }
+	static unsigned int _htoi(const QString&);
+	static bool _validHexText(const QString&, unsigned int maxlen);
 signals:
 
 public slots:
@@ -29,6 +35,8 @@ private:
 	std::map<int,QColor> mHighlight;
 	static const int mRows = 4096;
 	static const int mColumns = 16;
+	bool mEditable;
+	bool mDirty;
 
 };
 

--- a/src/VM.hpp
+++ b/src/VM.hpp
@@ -44,7 +44,7 @@ class VM {
 		unsigned int CalcInstructionLen();
 		size_t GetNumInstructions() { return mInstructions.size(); }
 		const std::vector<IPeripheral*> & GetDevices() { return mProc.GetDevices(); }
-		const Processor & GetProc() { return mProc; }
+		Processor & GetProc() { return mProc; }
 		unsigned char GetMemory(unsigned int addr);
 		const unsigned char* GetMemPtr() const { return mMem.getPtr(); }
 


### PR DESCRIPTION
The register, flags, and memory views on the GUI are now editable, and update the processor state appropriately.

Checking for valid input is included, and data is always reformatted properly after the input has been accepted.

Ex. Set AX to '1a', press enter, textbox will repopulate with '001A'
